### PR TITLE
chore(ci): pin base-ci reusable workflow to v2026.5 SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
     with:
       ignore-scripts: true
       test-command: "bun run test:coverage"


### PR DESCRIPTION
## Summary

把 base-ci reusable workflow 从浮动 tag 升级到 v2026.5 的不可变 commit SHA：

```diff
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.X
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
```

## Why

浮动 tag (`@v2026.X`) 在 base-ci 重打 tag 或被 force-push 时会静默切到不同 commit，违反 GitHub Actions 供应链最佳实践。SHA pin 把第三方 reusable workflow 引用变成字节级不可变，即使 base-ci 自身被入侵也不会拉到恶意代码。

## Verification

- 所有 `nocoo/base-ci` 引用都换成 `@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5`
- 没有任何残留的 `@v2026.x` 浮动引用
- `actionlint .github/workflows/*.yml` clean

## Multica

Tracked in [STU-906] (Studio workspace, Dev-Personal squad).

---

🤖 Part of a 40-repo base-ci supply-chain hardening campaign.