### PR TITLE
chore: add root .npmrc for supply chain security baseline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# ===== Supply chain security =====
+# Pin to official npm registry (防钓鱼源)
+registry=https://registry.npmjs.org/
+
+# ===== Lockfile integrity =====
+# Pin exact versions on npm install (防 minor/patch 漂移)
+save-exact=true
+# Always maintain package-lock (防 lockfile 被删)
+package-lock=true
+
+# ===== Environment consistency =====
+# Enforce engines field (防 Node/npm 版本不匹配)
+engine-strict=true
+
+# ===== Audit strategy =====
+# Auto-run audit on install
+audit=true
+# Fail install on high+ severity
+audit-level=high
+# Silence funding output (noise reduction)
+fund=false


### PR DESCRIPTION
## Summary

添加根级 `.npmrc` 供应链安全基线：pin 官方 npm registry、启用 audit（high+）、强制 lockfile 完整性（save-exact + package-lock）、engine-strict。

## 改动范围

- 仅新增根目录 `.npmrc`（21 行）
- 无 `package.json`、`bun.lock`、`bunfig.toml`、CI、hooks 或其他文件改动
- 未运行 `bun install` / `npm install`

## Verification

- `git diff HEAD~1 --stat` → `.npmrc | 21 +++++++++++++++++++++`
- 内容与 issue 模板逐字一致

Refs STU-1556.
